### PR TITLE
`optional` now rejects all falsy values except `null`, `undefined`

### DIFF
--- a/contract.impl.js
+++ b/contract.impl.js
@@ -285,7 +285,7 @@ exports.ContractLibraryError = ContractLibraryError;
 //
 
 function checkWContext(contract, data, context) {
-  if (contract.isOptional && !data) {
+  if (contract.isOptional && isMissing(data)) {
     // ok
   } else {
     if (!contract.firstChecker(data)) {
@@ -304,7 +304,7 @@ function checkWContext(contract, data, context) {
 }
 
 function wrapWContext(contract, data, context) {
-  if (contract.isOptional && !data) {
+  if (contract.isOptional && isMissing(data)) {
     return data;
   } else {
     return contract.wrapper(data, function (nextContract, nextV, nextContext) {
@@ -981,7 +981,7 @@ function fnHelper(who, argumentContracts) {
         // does not check results according to constructor-invocation semantics.
         // The actual result check is done below.
         var wrappedFnWithoutResultCheck = oldWrapper.call(gentleUpdate(self, { resultContract: any }), fn, next, context);
-        
+
         var WrappedConstructor = function (/* ... */) {
           var contextHere = clone(context);
           contextHere.stack = clone(context.stack);
@@ -994,7 +994,7 @@ function fnHelper(who, argumentContracts) {
           // cf. http://stackoverflow.com/a/1978474/35902
           var resultToCheck;
           if (_.isObject(receivedResult)) {
-            resultToCheck = receivedResult; 
+            resultToCheck = receivedResult;
           } else {
             resultToCheck = this;
           }

--- a/contract.spec.js
+++ b/contract.spec.js
@@ -223,12 +223,18 @@ describe ("object", function () {
   it ("fails missing field", function () { (function () { c.object({x: c.value(5), y:c.value(10)}).check({ x: 5, z: 10}); }).should.throwContract(); });
   it ("fails missing field, nested", function () { (function () { c.object({x: c.object({y: c.value(5)})}).check({x: { z: 10}}); }).should.throwContract(); });
 
-  it ("optional field missing", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5}).should.ok; });
-  it ("optional field, passing", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5, y:10}).should.ok; });
-  it ("optional field, failing", function () { (function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({ x: 5, y:5}); }).should.throwContract(); });
-  it ("optional field, nested, failing", function () { (function () { c.object({x: c.value(5), y: c.optional(c.object({z: c.value(10)}))})
-                                                                      .check({x: 5, y:{z: 0}}); })
-                                                       .should.throwContract(); });
+  describe ("option field", function () {
+    it ("when missing", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5}).should.ok; });
+    it ("when null", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5, y: null}).should.ok; });
+    it ("when undefined", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5, y: undefined}).should.ok; });
+    it ("when present", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5, y:10}).should.ok; });
+    it ("rejects when mismatched", function () { (function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({ x: 5, y:5}); }).should.throwContract(); });
+    it ("rejects when falsy", function () { (function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({ x: 5, y:""}); }).should.throwContract(); });
+    it ("rejects when NaN", function () { (function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({ x: 5, y:0/0}); }).should.throwContract(); });
+    it ("nested and mismatched", function () { (function () { c.object({x: c.value(5), y: c.optional(c.object({z: c.value(10)}))})
+                                                              .check({x: 5, y:{z: 0}}); })
+                                               .should.throwContract(); });
+  });
 
   it ("extra fields, passing", function () { c.object({x: c.value(5)}).check({x:5, y:10}).should.eql({x:5, y:10}); });
   it ("extra fields, wrapping", function () { c.object({fn: c.fn()}).wrap({fn: function () {}, x: 5}).x.should.eql(5); });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rho-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Racket-style Higher Order Contracts in Plain Javascript",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
@sashaverma Here's the fix for the `NaN` versus `optional` bug.