### PR TITLE
Don't install test and doc dependencies in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   ],
   "dependencies": {
     "callsite": "1.0.0",
-    "marked": "^0.3.5",
-    "mustache": "0.7.x",
-    "should": "1.2.2",
     "underscore": "1.8.x"
   },
   "devDependencies": {
+    "jshint": "^2.9.1",
+    "marked": "^0.3.5",
     "mocha": "1.14.x",
-    "jshint": "^2.9.1"
+    "mustache": "0.7.x",
+    "should": "1.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was surprised to see `should` installed along with `rho-contracts`. After a quick look, it seems like these dependencies are only imported to test or build doc, and are not required in projects which consume rho-contracts.