### PR TITLE
Make an official fork in npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@
 
 
 
-rho-contracts.js
-===============
+rho-contracts-fork
+==================
 
 Racket-style Higher-Order Contracts in Plain JavaScript
+
+This is a fork of [sefaira/rho-contracts.js][], maintained by the original
+author. The maintainer of tiny-lr is on hiatus, and this fork takes care of
+lingering issues until the maintainer (hopefully) returns.
+
+[sefaira/rho-contracts.js]: https://github.com/sefaira/rho-contracts.js
+
 
 ## Table of Content
 [Installation](#installation)  
@@ -35,7 +42,7 @@ Racket-style Higher-Order Contracts in Plain JavaScript
 <a name="installation"/>
 ## Installation
 
-`npm install rho-contracts`
+`npm install rho-contracts-fork`
 
 <a name="introduction"/>
 ## Introduction
@@ -87,7 +94,7 @@ possible to place the specification next to the definition of `derive`, where it
 belongs, like this:
 
 ```javascript
-var c = require('rho-contracts')
+var c = require('rho-contracts-fork')
 
 // derive: returns a function that is the numerically-computed derivative
 //         of the given function.
@@ -255,7 +262,7 @@ for the `dx` argument of the call.
 The contract library is typically `require`'d and bound to a variable called `c`:
 
 ```javascript
-c = require('rho-contracts')
+c = require('rho-contracts-fork')
 ```
 
 <a name="basic-value"/>
@@ -360,7 +367,7 @@ your node module and keep the contracts created and used in that module in the c
 
 ```javascript
 > var _ = require('underscore')
-> var c = _.clone(require('rho-contracts'));
+> var c = _.clone(require('rho-contracts-fork'));
 > c.numberAsString = c.matches(/^[0-9]+(\.[0-9]+)?$/)
 > c.or(c.falsy, c.numberAsString).check(null)     // ok, null is falsy
 null
@@ -565,7 +572,7 @@ argument, a contract that has been marked optional makes that argument optional
 argument must be optional as well.
 
 ```javascript
-> var c = require('rho-contracts')
+> var c = require('rho-contracts-fork')
 > var util = require('util')
 
 > var x = 0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+-------------------------------------------------------------------------------
+
 <!--- This Source Code Form is subject to the terms of the Mozilla Public
     - License, v. 2.0. If a copy of the MPL was not distributed with this
     - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
@@ -9,9 +11,15 @@ rho-contracts-fork
 
 Racket-style Higher-Order Contracts in Plain JavaScript
 
-This is a fork of [sefaira/rho-contracts.js][], maintained by the original
-author. The maintainer of tiny-lr is on hiatus, and this fork takes care of
-lingering issues until the maintainer (hopefully) returns.
+This is a fork of [sefaira/rho-contracts.js][] which is maintained by the
+original author and the team at Body Labs. The maintainers under the
+`sefaira/` account are on hiatus, so this fork will continue
+rho-contracts' maintenance and development, notably
+
+* Implemented support for ES6 classes
+* Improved stack trace support across more browsers
+
+
 
 [sefaira/rho-contracts.js]: https://github.com/sefaira/rho-contracts.js
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rho-contracts",
+  "name": "rho-contracts-fork",
   "version": "1.2.2",
   "description": "Racket-style Higher Order Contracts in Plain Javascript",
   "main": "index.js",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bodylabs/rho-contracts.js.git"
+    "url": "https://github.com/bodylabs/rho-contracts-fork.git"
   },
   "readmeFilename": "README.md",
   "gitHead": "aef2505b61452b8322c0d5ec57144190ac09f175",


### PR DESCRIPTION
Since Sefaira isn't able to maintain the package at this time, it seems prudent to publish a new package in npm.

This way, we can take advantage of automatic dependency solving, and also publish subpackages which depend on our fork.

Hopefully down the line we can merge back with Sefaira, or perhaps someone with access there will decide to let us publish updates to the original npm package.

I'm thinking we can rename the repo too, for clarity.

This is the package I'd seen do this before: https://www.npmjs.com/package/tiny-lr-fork The fork maintainer is now maintaining the new package.